### PR TITLE
fix error when absolute path is provied in 'pgmigrate new --migrations'

### DIFF
--- a/cmd/pgmigrate/root/new.go
+++ b/cmd/pgmigrate/root/new.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -120,10 +119,6 @@ pgmigrate new vim_user_example --create --bare | xargs vim
 		id := fmt.Sprintf("%s_%s", prefix, suffix)
 		filename := fmt.Sprintf("%s.sql", id)
 		fp := path.Join(dir, filename)
-		fp, err = filepath.Rel(".", fp)
-		if err != nil {
-			return err
-		}
 		if *NewFlags.Create {
 			if err := os.WriteFile(fp, []byte(`-- write your migration here`), 0o660); err != nil {
 				return err


### PR DESCRIPTION
A possible fix for #1.
Not sure why we need `filepath.Rel` at all.
`os.WriteFile` works with both absolute and relative paths, so user can provide either and it should work out of the box.

Smoke test after the fix:
```
 ./main new --migrations $(pwd)/example/migrations
INFO created id=00004_generated path=/Users/vvkh/Projects/pgmigrate/example/migrations/00004_generated.sql

./main new --migrations example/migrations 
INFO created id=00004_generated path=example/migrations/00004_generated.sql
```