### PR TITLE
fix: load triggers even when they share a name

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -28,11 +28,11 @@ jobs:
           --health-retries 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
           cache: true
           cache-dependency-path: go.sum
       - name: test all
@@ -40,19 +40,30 @@ jobs:
       - name: test all -race
         run: go test -count=1 -race ./... ./cmd/pgmigrate/...
   lint:
+    # https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#annotations
+    permissions:
+      contents: read # read the repo
+      pull-requests: read # allows the 'only-new-issues' option to work
+      checks: write # annotate code in the PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.52.2
+          install-mode: "binary"
+          version: "v1.57.1"
+          # https://github.com/golangci/golangci-lint-action/issues/244
+          # https://github.com/Kong/mesh-perf/pull/168
+          # https://github.com/golangci/golangci-lint-action/issues/552#issuecomment-1413509544
+          args: --timeout 10m
+          skip-cache: true
       - name: go mod tidy
         run: go mod tidy
       - name: check for any changes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,11 +12,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: setup-go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: 1.22
         cache: true
         cache-dependency-path: go.sum
     - name: release-darwin-amd64

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,11 @@
+# yaml-language-server: $schema=https://json.schemastore.org/golangci-lint.json
 # https://golangci-lint.run/usage/configuration/
 linters-settings:
+  gocritic:
+    disabled-checks:
+      - ifElseChain
   goimports:
-    local-prefixes: github.com/rubenv/sql-migrate
+    local-prefixes: github.com/peterldowns/pgmigrate
   govet:
     enable-all: true
     disable:
@@ -10,11 +14,10 @@ linters-settings:
     default-signifies-exhaustive: true
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     allow-no-explanation:
-      - depguard
       - gochecknoglobals
       - gochecknoinits
+      - unparam
     require-explanation: true
     require-specific: true
   # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
@@ -35,7 +38,7 @@ linters-settings:
           - allowTypesBefore: "*testing.T"
       - name: context-keys-type
       - name: datarace
-      - name: deep-exit
+      # - name: deep-exit
       - name: defer
       - name: dot-imports
       - name: duplicated-imports
@@ -46,22 +49,27 @@ linters-settings:
       - name: error-return
       - name: error-strings
       - name: errorf
-      - name: exported
-      - name: flag-parameter
+      # - name: exported
       - name: function-result-limit
         arguments: [3]
       - name: get-return
       - name: identical-branches
       - name: if-return
-      - name: imports-blacklist
-        arguments: []
+      - name: imports-blocklist
+        arguments:
+          - "github.com/cockroachdb/errors"
+          - "github.com/sirupsen/logrus"
+          - "github.com/stretchr/testify"
+          - "github.com/stretchr/testify/require"
+          - "github.com/stretchr/testify/assert"
+          - "log"
       - name: import-shadowing
       - name: increment-decrement
       - name: indent-error-flow
       - name: modifies-parameter
       - name: modifies-value-receiver
-      - name: nested-structs
-      - name: package-comments
+      # - name: nested-structs
+      # - name: package-comments
       - name: range
       - name: range-val-address
       - name: range-val-in-closure
@@ -91,12 +99,12 @@ linters-settings:
 run:
   tests: true
   timeout: 1m
+
 # https://golangci-lint.run/usage/linters/
 linters:
   disable-all: true
   enable:
     - asciicheck
-    - depguard
     - errcheck
     - exhaustive
     - gocritic
@@ -118,8 +126,19 @@ linters:
     - gosimple
     - unparam
 issues:
+  exclude-use-default: false
   exclude:
     # Allow shadowing of `err` because it's so common
     - 'declaration of "err" shadows declaration at'
+    # Allow writing tags on non-exported fields, necessary for graphql
+    - "tag on not-exported field"
+    # Upstream Defaults from
+    # https://golangci-lint.run/usage/false-positives/#default-exclusions
+    - 'Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked'
+  exclude-rules: []
   max-same-issues: 10000
   max-issues-per-linter: 10000
+  exclude-dirs-use-default: false
+  exclude-dirs:
+    - ^/nix/store/.*
+    - .*/.toolchain-*/.*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,24 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "debug python",
-            "type": "python",
-            "request": "launch",
-            "mode": "debug",
-            "args": ["main.py"],
-            "program": "python3",
-
-        },
-        {
-            "name": "debug golang",
+            "name": "debug dump",
             "type": "go",
             "request": "launch",
             "mode": "debug",
             "env": {
                 "PGM_CONFIGFILE": "/Users/pd/code/pgmigrate/.pgmigrate.yaml"
             },
-            "args": ["dump"],
-            "program": "./cli",
+            "args": ["dump", "--out", "-"],
+            "program": "./cmd/pgmigrate",
 
         }
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,12 @@
   "go.coverOnSingleTest": true,
   "go.coverOnSingleTestFile": true,
   "go.lintTool": "golangci-lint",
-  "go.lintFlags": ["--config=${workspaceFolder}/.golangci.yaml", "--fast", "--fix"],
-  "go.lintOnSave": "package",
+  "go.lintFlags": [
+    "--config=${workspaceFolder}/.golangci.yaml",
+    "--fast",
+    "--fix"
+  ],
+  "go.lintOnSave": "workspace",
   "go.testEnvVars": {},
   "go.testFlags": ["-tags", "manual"],
   "go.coverageOptions": "showCoveredCodeOnly",

--- a/cmd/pgmigrate/main.go
+++ b/cmd/pgmigrate/main.go
@@ -31,5 +31,5 @@ func main() {
 func onError(err error) {
 	msg := fmt.Sprintf("error: %s", err)
 	_, _ = fmt.Fprintln(os.Stderr, color.New(color.FgRed, color.Italic).Sprintf(msg))
-	os.Exit(1) //nolint:revive // intentional error handling
+	os.Exit(1)
 }

--- a/cmd/pgmigrate/root/applied.go
+++ b/cmd/pgmigrate/root/applied.go
@@ -23,7 +23,7 @@ command will print nothing and exit successfully.
 	`),
 	GroupID:          "migrating",
 	TraverseChildren: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		shared.State.Parse()
 		migrations := shared.State.Migrations()
 		database := shared.State.Database()

--- a/cmd/pgmigrate/root/dump.go
+++ b/cmd/pgmigrate/root/dump.go
@@ -65,7 +65,7 @@ diff schema.sql another.sql # should show no differences
 	`),
 	GroupID:          "dev",
 	TraverseChildren: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		if len(args) == 1 && *DumpFlags.Out == "" {
 			*DumpFlags.Out = args[0]
 		}

--- a/cmd/pgmigrate/root/migrate.go
+++ b/cmd/pgmigrate/root/migrate.go
@@ -59,7 +59,7 @@ Finally, the advisory lock is released.
 	`),
 	GroupID:          "migrating",
 	TraverseChildren: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		shared.State.Parse()
 		database := shared.State.Database()
 		migrations := shared.State.Migrations()

--- a/cmd/pgmigrate/root/new.go
+++ b/cmd/pgmigrate/root/new.go
@@ -67,7 +67,7 @@ pgmigrate new vim_user_example --create --bare | xargs vim
 	`),
 	GroupID:          "dev",
 	TraverseChildren: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		if len(args) == 1 && *NewFlags.Name == "" {
 			*NewFlags.Name = args[0]
 		}

--- a/cmd/pgmigrate/root/plan.go
+++ b/cmd/pgmigrate/root/plan.go
@@ -57,7 +57,7 @@ problems.
 	`),
 	GroupID:          "migrating",
 	TraverseChildren: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		shared.State.Parse()
 		database := shared.State.Database()
 		migrations := shared.State.Migrations()

--- a/cmd/pgmigrate/root/verify.go
+++ b/cmd/pgmigrate/root/verify.go
@@ -24,7 +24,7 @@ Otherwise, succeeds without printing anything and exits with status code 0.
 	`),
 	GroupID:          "migrating",
 	TraverseChildren: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		shared.State.Parse()
 		database := shared.State.Database()
 		migrations := shared.State.Migrations()
@@ -52,7 +52,7 @@ Otherwise, succeeds without printing anything and exits with status code 0.
 			slogger.With(attrs...).Warn(verr.Message)
 		}
 		if len(verrs) != 0 {
-			os.Exit(1) //nolint:revive // deep-exit
+			os.Exit(1)
 		}
 		return nil
 	},

--- a/internal/schema/trigger_test.go
+++ b/internal/schema/trigger_test.go
@@ -1,0 +1,93 @@
+package schema_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/peterldowns/testy/assert"
+	"github.com/peterldowns/testy/check"
+
+	"github.com/peterldowns/pgmigrate/internal/schema"
+	"github.com/peterldowns/pgmigrate/internal/withdb"
+)
+
+var schemaWithTriggers = query(`--sql
+CREATE OR REPLACE FUNCTION public.updated_at()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+  BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+  END;
+$function$
+;
+
+CREATE TABLE pull_requests (
+	id bigint primary key,
+	updated_at timestamptz not null default now()
+);
+
+CREATE TABLE background_jobs (
+	id bigint primary key,
+	updated_at timestamptz not null default now()
+);
+
+CREATE TABLE background_job_settings (
+	id bigint primary key,
+	updated_at timestamptz not null default now()
+);
+
+create trigger updated_at
+before update on pull_requests
+for each row execute procedure updated_at(); -- PROCEDURE
+
+create trigger updated_at
+before update on background_jobs
+for each row execute function updated_at(); -- FUNCTION
+
+create trigger updated_at
+before update on background_job_settings
+for each row execute function updated_at(); -- FUNCTIOn
+	`)
+
+func TestLoadTriggersWithSameName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	err := withdb.WithDB(ctx, "pgx", func(db *sql.DB) error {
+		if _, err := db.ExecContext(ctx, schemaWithTriggers); err != nil {
+			return err
+		}
+		config := schema.Config{Schema: "public"}
+		_, err := schema.LoadTables(config, db)
+		if err != nil {
+			return err
+		}
+		triggers, err := schema.LoadTriggers(config, db)
+		if err != nil {
+			return err
+		}
+		// Check that there are 3 separate triggers, not 1, because the three
+		// triggers all have the same name and there used to be a bug where only
+		// 1 would be returned.
+		check.Equal(t, 3, len(triggers))
+		return nil
+	})
+	assert.Nil(t, err)
+}
+
+func TestLoadTriggersWithoutAnyTriggers(t *testing.T) {
+	t.Parallel()
+	config := schema.Config{Schema: "public"}
+	ctx := context.Background()
+	err := withdb.WithDB(ctx, "pgx", func(db *sql.DB) error {
+		views, err := schema.LoadTriggers(config, db)
+		if err != nil {
+			return err
+		}
+		check.Equal(t, []*schema.Trigger{}, views)
+		return nil
+	})
+	assert.Nil(t, err)
+}

--- a/internal/schema/triggers.go
+++ b/internal/schema/triggers.go
@@ -17,7 +17,8 @@ type Trigger struct {
 }
 
 func (t Trigger) SortKey() string {
-	return t.Name
+	// Triggers on different tables may have the same name
+	return identifier(t.TableName, t.Name)
 }
 
 func (t Trigger) DependsOn() []string {

--- a/migratorops.go
+++ b/migratorops.go
@@ -73,7 +73,7 @@ func (m *Migrator) MarkApplied(ctx context.Context, db Executor, ids ...string) 
 				ON CONFLICT DO NOTHING;`,
 				pgtools.QuoteIdentifier(m.TableName),
 			)
-			_, err := db.ExecContext(ctx, query, ma.ID, ma.Checksum, ma.ExecutionTimeInMillis, ma.AppliedAt)
+			_, err := tx.ExecContext(ctx, query, ma.ID, ma.Checksum, ma.ExecutionTimeInMillis, ma.AppliedAt)
 			if err != nil {
 				msg := "failed to mark migration as applied"
 				m.error(ctx, err, msg, fields...)
@@ -145,7 +145,7 @@ func (m *Migrator) MarkUnapplied(ctx context.Context, db Executor, ids ...string
 		query := fmt.Sprintf(`
 			DELETE FROM %s WHERE id = any($1) RETURNING *;
 		`, pgtools.QuoteIdentifier(m.TableName))
-		rows, err := db.QueryContext(ctx, query, toRemove)
+		rows, err := tx.QueryContext(ctx, query, toRemove)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func (m *Migrator) SetChecksums(ctx context.Context, db Executor, updates ...Che
 				`UPDATE %s SET checksum = $1 where id = $2 and checksum != $1`,
 				pgtools.QuoteIdentifier(m.TableName),
 			)
-			_, err := db.ExecContext(ctx, query, migration.Checksum, migration.ID)
+			_, err := tx.ExecContext(ctx, query, migration.Checksum, migration.ID)
 			if err != nil {
 				msg := "failed to set checksum"
 				m.error(ctx, err, msg, fields...)


### PR DESCRIPTION
The `LoadTriggers` function was not properly returning all of the triggers in the database, resulting in missing triggers in the resulting `Schema` object and in the final results of `pgmigrate dump`. The root cause was that triggers may share the same name as long as they're attached to different tables, but the `SortKey()` implementation for a `Trigger` only used the `trigger.Name`. This led to triggers colliding during the sorting process, with just one trigger of a given name making it to the result.

The fix is to use a combination of the trigger's table and its name during the sorting process. I confirmed the problem and the fix by writing unit tests — trigger loading was previously untested.

While developing this fix, I noticed that the golangci-lint configuration was resulting in many lint errors. I updated this configuration and fixed these lint errors. The only change that affects behavior was that in the `migratorops` code, there were multiple cases of a transaction `tx` being opened but then queries would be run against the `db`, not the `tx`.

The breaking behavioral change is that in the `mark-applied`, `mark-unapplied`, and `set-checksums` operations, *now* either all of the migration records are updated or none of them are. Previously, some could succeed while others later failed.