### PR TITLE
fix(cmd): use --table-name flag in cli

### DIFF
--- a/cmd/pgmigrate/root/applied.go
+++ b/cmd/pgmigrate/root/applied.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/peterldowns/pgmigrate"
 	"github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared"
 )
 
@@ -39,7 +38,12 @@ command will print nothing and exit successfully.
 		}
 		defer db.Close()
 
-		applied, err := pgmigrate.Applied(cmd.Context(), db, dir, mlogger)
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
+
+		applied, err := m.Applied(cmd.Context(), db)
 		if err != nil {
 			return err
 		}

--- a/cmd/pgmigrate/root/migrate.go
+++ b/cmd/pgmigrate/root/migrate.go
@@ -7,7 +7,6 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx driver
 	"github.com/spf13/cobra"
 
-	"github.com/peterldowns/pgmigrate"
 	"github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared"
 )
 
@@ -75,7 +74,12 @@ Finally, the advisory lock is released.
 		}
 		defer db.Close()
 
-		verrs, err := pgmigrate.Migrate(cmd.Context(), db, dir, mlogger)
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
+
+		verrs, err := m.Migrate(cmd.Context(), db)
 		if err != nil {
 			return err
 		}

--- a/cmd/pgmigrate/root/new.go
+++ b/cmd/pgmigrate/root/new.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"strconv"
@@ -137,4 +138,15 @@ func init() {
 	NewFlags.Bare = newCmd.Flags().BoolP("bare", "b", false, "if true, only print the created migration file path")
 	NewFlags.Create = newCmd.Flags().BoolP("create", "c", false, "if true, create the migration file")
 	NewFlags.Name = newCmd.Flags().StringP("name", "n", "", "the name of the new migration (default 'generated')")
+}
+
+func newMigrator(dir fs.FS, tableName string, logger pgmigrate.Logger) (*pgmigrate.Migrator, error) {
+	migrations, err := pgmigrate.Load(dir)
+	if err != nil {
+		return nil, fmt.Errorf("load migrations: %w", err)
+	}
+	m := pgmigrate.NewMigrator(migrations)
+	m.Logger = logger
+	m.TableName = tableName
+	return m, nil
 }

--- a/cmd/pgmigrate/root/plan.go
+++ b/cmd/pgmigrate/root/plan.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/peterldowns/pgmigrate"
 	"github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared"
 )
 
@@ -73,7 +72,12 @@ problems.
 		}
 		defer db.Close()
 
-		plan, err := pgmigrate.Plan(cmd.Context(), db, dir, mlogger)
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
+
+		plan, err := m.Plan(cmd.Context(), db)
 		if err != nil {
 			return err
 		}

--- a/cmd/pgmigrate/root/verify.go
+++ b/cmd/pgmigrate/root/verify.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/peterldowns/pgmigrate"
 	"github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared"
 )
 
@@ -40,7 +39,12 @@ Otherwise, succeeds without printing anything and exits with status code 0.
 		}
 		defer db.Close()
 
-		verrs, err := pgmigrate.Verify(cmd.Context(), db, dir, mlogger)
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
+
+		verrs, err := m.Verify(cmd.Context(), db)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Make CLI use the command-line flag for migration table name by initializing a new `pgmigrate.Migrator` for each command, which allows setting up the table name. 

No API changes.

related to https://github.com/peterldowns/pgmigrate/issues/3