### PR TITLE
dx: remove superfluous vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,7 @@
 {
     "recommendations": [
-      "charliermarsh.ruff",
       "golang.go",
       "jnoortheen.nix-ide",
-      "ms-python.python",
-      "ms-vscode.powershell",
       "skellock.just",
       "timonwong.shellcheck"
     ]


### PR DESCRIPTION
These extensions aren't necessary for working in this
repository, they were included by accident.
