### PR TITLE
ci: speed up action workflows

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -55,15 +55,10 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v6
         with:
           install-mode: "binary"
           version: "v1.57.1"
-          # https://github.com/golangci/golangci-lint-action/issues/244
-          # https://github.com/Kong/mesh-perf/pull/168
-          # https://github.com/golangci/golangci-lint-action/issues/552#issuecomment-1413509544
-          args: --timeout 10m
-          skip-cache: true
       - name: go mod tidy
         run: go mod tidy
       - name: check for any changes

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -35,6 +35,7 @@ jobs:
           go-version: 1.22
           cache: true
           cache-dependency-path: go.sum
+      - run: go mod download
       - name: test all
         run: go test -count=1 ./... ./cmd/pgmigrate/...
       - name: test all -race
@@ -54,6 +55,7 @@ jobs:
           go-version: 1.22
           cache: true
           cache-dependency-path: go.sum
+      - run: go mod download
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -7,30 +7,22 @@ on:
 jobs:
   nix-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@v4
-    - name: Install Nix
-      uses: cachix/install-nix-action@v30
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - name: build and run with nix
-      run: nix run .#pgmigrate -- --help
+    - uses: DeterminateSystems/nix-installer-action@v16
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
+    - run: nix run .#pgmigrate -- --help
   nix-lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install Nix
-      uses: cachix/install-nix-action@v30
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - name: flake check
-      run: nix flake check
-    - name: lint & format
-      run: |
+    - uses: DeterminateSystems/nix-installer-action@v16
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
+    - run: nix flake check
+    - run: |
         nix develop --command nixpkgs-fmt --check *.nix
         if ! git diff-index --quiet HEAD --; then
           echo "nixpkgs-fmt had changes"

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -5,32 +5,34 @@ on:
       - main
   pull_request:
 jobs:
-  build:
+  nix-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Nix
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - name: Install Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v1
-    - run: nix flake check
-    - name: lint formatting
+    - name: build and run with nix
+      run: nix run .#pgmigrate -- --help
+  nix-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Nix
+      uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - name: flake check
+      run: nix flake check
+    - name: lint & format
       run: |
         nix develop --command nixpkgs-fmt --check *.nix
         if ! git diff-index --quiet HEAD --; then
           echo "nixpkgs-fmt had changes"
           exit 1
         fi
-    # flakes
-    - run: nix develop --command which go
-    - run: nix build . && ./result/bin/pgmigrate --help
-    - run: nix build .#pgmigrate && ./result/bin/pgmigrate --help
-    - run: nix run . -- --help
-    - run: nix run .#pgmigrate -- --help
-    # standard
-    - run: nix-shell --run 'which go'
-    - run: nix-build && ./result/bin/pgmigrate --help


### PR DESCRIPTION
- upgrade to golangci-lint-action@v6, which improves caching
- only check the nix flake builds
- split the nix build worfklow from the nix linting workflow
- install and cache nix things with the cachix actions