### PR TITLE
fix CGO-related Docker build issues

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.24
           cache: true
           cache-dependency-path: go.sum
       - run: go mod download
@@ -52,7 +52,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.24
           cache: true
           cache-dependency-path: go.sum
       - run: go mod download

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -57,10 +57,11 @@ jobs:
           cache-dependency-path: go.sum
       - run: go mod download
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
           install-mode: "binary"
-          version: "v1.57.1"
+          version: "v1.64.5"
+          verify: true
       - name: go mod tidy
         run: go mod tidy
       - name: check for any changes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: setup-go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.24
         cache: true
         cache-dependency-path: go.sum
     - name: release-darwin-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Stage
 # Pin to the latest minor version without specifying a patch version so that
 # we always deploy security fixes as soon as they are available.
-FROM golang:1.22-alpine as builder
+FROM golang:1.22-alpine AS builder
 RUN apk add build-base git
 
 # Have to put our source in the right place for it to build
@@ -37,7 +37,7 @@ RUN go build \
   ./cmd/pgmigrate
 
 # App Stage
-FROM alpine:3.16.3 as app
+FROM alpine:3.16.3 AS app
 
 # Add a non-root user and group with appropriate permissions
 # and consistent ids.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Stage
 # Pin to the latest minor version without specifying a patch version so that
 # we always deploy security fixes as soon as they are available.
-FROM golang:1.22-alpine AS builder
+FROM golang:1.24-alpine AS builder
 RUN apk add build-base git
 
 # Have to put our source in the right place for it to build
@@ -37,7 +37,7 @@ RUN go build \
   ./cmd/pgmigrate
 
 # App Stage
-FROM alpine:3.16.3 AS app
+FROM alpine:3.21 AS app
 
 # Add a non-root user and group with appropriate permissions
 # and consistent ids.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add build-base git
 WORKDIR $GOPATH/src/github.com/peterldowns/pgmigrate
 
 ENV GO111MODULE=on
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 
 # Install the dependencies
 COPY go.mod .

--- a/Justfile
+++ b/Justfile
@@ -65,7 +65,7 @@ update-version version:
   sed -i -e "s/$OLD_VERSION/$NEW_VERSION/g" **/README.md
   sed -i -e "s/pgmigrate $OLD_VERSION/pgmigrate $NEW_VERSION/g" **/go.mod
 
-# builds and pushes tbd-dbtools/migrate, tagged with :latest and :$COMMIT_SHA
+# builds local-pgmigrate, tagged with :latest and :$COMMIT_SHA
 build-docker:
   #!/usr/bin/env bash
   COMMIT_SHA=$(git rev-parse --short HEAD || echo "unknown")

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,7 @@ test *args='./... ./cmd/pgmigrate/...':
 
 # lint pgmigrate
 lint *args='./... ./cmd/pgmigrate/...':
+  golangci-lint config verify --config .golangci.yaml
   golangci-lint run --fix --config .golangci.yaml $@
 
 # lint nix files

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711912510,
-        "narHash": "sha256-m/FBphwnP4JOCOIrPDVt7vGlf0rmN2w+yaeU8KzoMD8=",
-        "owner": "nixos",
+        "lastModified": 1739740471,
+        "narHash": "sha256-5QO5/GdwYcOkAlXl579JefJ0IaUsTrQfirVbLRCmZFc=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8d649e4b26df1701b40dd81342f38dbc29382b8",
+        "rev": "888ab7d2844c0578ef8c33b2b591f6c531292cb1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       in
       rec {
         packages = rec {
-          pgmigrate = pkgs.buildGoModule {
+          pgmigrate = pkgs.buildGo124Module {
             pname = "pgmigrate";
             version = version;
             # Every time you update your dependencies (go.mod / go.sum)  you'll
@@ -83,7 +83,7 @@
               # Go
               delve
               go-outline
-              go
+              go_1_24
               golangci-lint
               gopkgs
               gopls


### PR DESCRIPTION
I'm seeing cgo-related errors on the `main` branch:

https://github.com/peterldowns/pgmigrate/actions/runs/13402236158/job/37435471414

```
#41 [linux/arm64 builder 13/13] RUN go build   -ldflags "-X github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared.Version=v0.2.0 -X github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared.Commit=639e8e5"   -o /dist/pgmigrate   ./cmd/pgmigrate
#41 35.55 # runtime/cgo
#41 35.55 gcc: error: unrecognized command-line option '-fno-caret-diagnostics'
#41 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c go build   -ldflags \"-X github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared.Version=${PGM_VERSION} -X github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared.Commit=${PGM_COMMIT_SHA}\"   -o /dist/pgmigrate   ./cmd/pgmigrate" did not complete successfully: exit code: 1
------
 > [linux/arm64 builder 13/13] RUN go build   -ldflags "-X github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared.Version=v0.2.0 -X github.com/peterldowns/pgmigrate/cmd/pgmigrate/shared.Commit=639e8e5"   -o /dist/pgmigrate   ./cmd/pgmigrate:
35.55 # runtime/cgo
35.55 gcc: error: unrecognized command-line option '-fno-caret-diagnostics'
------
```

This is absolutely terrible. I have no idea why gcc is failing. But, here's how I'm trying to fix it:

- Update the development shell and the nix build to use go1.24
    - also update golangci-lint in CI to match the version used in development
    - we have to update it in CI for it to be able to work with code built with go1.24, anyway
- Update CI to use go1.24, both for the golang workflows and the docker workflows
- Update the Dockerfile to use go1.24 and alpine 3.21
- Update the Dockerfile to set `CGO_ENABLED=0`
    -  I don't know why it was set to `CGO_ENABLED=1`
    - The local development shell sets `CGO_ENABLED=0` and pgmigrate still seems to work fine
    - The [release binaries](https://github.com/peterldowns/pgmigrate/blob/639e8e59790156246175300c271ed5c807f57821/.github/workflows/release.yaml#L25) are built with `CGO_ENABLED=0`, and those are what people are `brew` installing, and everything seems to work fine.

I tested this change by running `just docker-build` and then running `docker run --rm -it local-pgmigrate:latest pgmigrate version` and it seemed to work correctly, so hopefully everything is cool.