### PR TITLE
fix: various issues with postgres:17

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: password
           # TODO: unable to turn off fsync easily, see

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   appdb:
-    image: postgres:15
+    image: postgres:17
     environment:
       POSTGRES_USER: appuser
       POSTGRES_DB: exampleapp
@@ -10,7 +10,7 @@ services:
     ports:
       - "5435:5432"
   testdb:
-    image: postgres:15
+    image: postgres:17
     environment:
       POSTGRES_USER: appuser
       POSTGRES_DB: testdb

--- a/internal/schema/domains.go
+++ b/internal/schema/domains.go
@@ -96,6 +96,11 @@ select
 			pg_catalog.pg_get_constraintdef(r.oid, true)
 		from pg_catalog.pg_constraint r
 		where t.oid = r.contypid
+		-- Work around bug in Postgres 17.0, 17.1, 17.2; fixed in 17.3, see
+		-- https://git.postgresql.org/cgit/postgresql.git/commit/?id=09d09d4297b9acbc2848ec35e8bf030d6c1fae18 —
+		-- and
+		-- https://www.postgresql.org/docs/release/17.3/ (search: pg_get_constraintdef)
+		and r.contype != 'n'
 	), ' ') as "check_constraints"
 from pg_catalog.pg_type t
 left join pg_catalog.pg_namespace n

--- a/internal/schema/views_test.go
+++ b/internal/schema/views_test.go
@@ -35,9 +35,9 @@ SELECT * from dogs;
 	`)
 	result := query(`--sql
 CREATE VIEW public.foobar AS
-   SELECT dogs.id,
-    dogs.name,
-    dogs.enemy_id
+   SELECT id,
+    name,
+    enemy_id
    FROM dogs;
 `)
 	checkView(t, original, result)

--- a/internal/withdb/withdb.go
+++ b/internal/withdb/withdb.go
@@ -4,7 +4,6 @@ package withdb
 
 import (
 	"context"
-	"crypto/md5"
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
@@ -60,14 +59,16 @@ func WithDB(ctx context.Context, driverName string, cb func(*sql.DB) error) (fin
 	return cb(testDB)
 }
 
+// randomID is a helper for coming up with the names of the instance databases.
+// It uses 32 random bits in the name, which means collisions are unlikely.
 func randomID(prefix string) (string, error) {
-	bytes := make([]byte, 32)
-	hash := md5.New()
+	bytes := make([]byte, 4)
 	_, err := rand.Read(bytes)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s_%s", prefix, hex.EncodeToString(hash.Sum(bytes))), nil
+	suffix := hex.EncodeToString(bytes)
+	return fmt.Sprintf("%s_%s", prefix, suffix), nil
 }
 
 func connectionString(dbname string) string {

--- a/internal/withdb/withdb_test.go
+++ b/internal/withdb/withdb_test.go
@@ -1,0 +1,22 @@
+package withdb_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // pgx driver for postgres
+	"github.com/peterldowns/testy/assert"
+
+	"github.com/peterldowns/pgmigrate/internal/withdb"
+)
+
+func TestWithDB(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	err := withdb.WithDB(ctx, "pgx", func(db *sql.DB) error {
+		_, err := db.Exec("select 1")
+		return err
+	})
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
After upgrading the docker-compose.yml for local tests to postgres:17, I observed a variety of failures. This PR fixes those failures, and updates the CI setup to also use postgres:17.

Issues discovered in 17:

- The tests were failing repeatedly because the very long test database names that were being generated by WithDB were getting truncated to 63 characters. When the helper tried to connect to the database with its full >63-character name, it wouldn't be able to connect because that full name didn't exist. The fix is to update the WithDB helper by adopting the shorter, just-as-random names generated by the logic introduced in https://github.com/peterldowns/pgtestdb/pull/17.
- The definition of materialized views seems to no longer include the name of the table when it isn't explicitly used as an alias, so I had to update one of the tests.
- There was an issue in postgres 17 (fixed in 17.3) where domains with NOT NULL constraints couldn't be parsed correctly due to `pg_get_constraintdef` failing on the not-null constraint. This was fixed upstream in 17.3 and I've also added a workaround in the code that fixed the problem when I ran on 17.0.

## Testing
- [x] locally running `just test` and seeing the previously-failing tests pass.
- [x] update CI to use postgres:17 and seeing it pass.