### PR TITLE
feat: add ls as alias for list

### DIFF
--- a/cmd/pgmigrate/root/applied.go
+++ b/cmd/pgmigrate/root/applied.go
@@ -10,7 +10,7 @@ import (
 
 var appliedCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:     "applied",
-	Aliases: []string{"list"},
+	Aliases: []string{"list", "ls"},
 	Short:   "Show all previously-applied migrations",
 	Long: shared.CLIHelp(`
 Prints the previously-applied migrations in the order that they were applied


### PR DESCRIPTION
This PR makes it possible to run `pgmigrate ls` as an alias for `pgmigrate list`, which is already an alias for `pgmigrate applied`. Solves a long-standing pet peeve of mine, I think all CLIs should let `ls` == `list`.

## Tests
I manually built and ran `pgmigrate ls` and `pgmigrate list` and saw that they did the same thing. We don't have any tests on the CLI.