### PR TITLE
fix: do not add unique constraint if is not explicitly defined (#28)

### DIFF
--- a/internal/schema/tables.go
+++ b/internal/schema/tables.go
@@ -58,8 +58,11 @@ func (t Table) String() string {
 				uniqueIndexes[index.SortKey()] = true
 				isPrimaryKey = true
 			}
-			if len(index.IndexColumns) == 1 && index.IndexColumns[0] == c.Name && index.IsUnique {
-				uniqueIndexes[index.SortKey()] = true
+		}
+		// Only mark column as unique if there's an actual UNIQUE constraint
+		// (not just a unique index which may be expression-based)
+		for _, constraint := range t.Constraints {
+			if constraint.Type == "unique" && len(constraint.LocalColumns) == 1 && constraint.LocalColumns[0] == c.Name {
 				isUnique = true
 			}
 		}

--- a/internal/schema/tables_test.go
+++ b/internal/schema/tables_test.go
@@ -1,0 +1,45 @@
+package schema_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/peterldowns/pgmigrate/internal/schema"
+)
+
+func TestExpressionBasedUniqueIndexes(t *testing.T) {
+	t.Parallel()
+	dbtest(t, query(`--sql
+CREATE TABLE public.tab_folders (
+    id_folder UUID PRIMARY KEY NOT NULL,
+    id_parent_folder UUID REFERENCES public.tab_folders(id_folder),
+    name jsonb NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_tab_folders_id_parent_folder_name_cs
+    ON public.tab_folders (id_parent_folder, (name->>'cs'))
+    WHERE name ? 'cs';
+
+CREATE UNIQUE INDEX idx_tab_folders_id_parent_folder_name_en
+    ON public.tab_folders (id_parent_folder, (name->>'en'))
+    WHERE name ? 'en';
+	`), func(db *sql.DB) error {
+		config := schema.DumpConfig{SchemaNames: []string{"public"}}
+		result, err := schema.Parse(config, db)
+		if err != nil {
+			return err
+		}
+
+		// Check that id_parent_folder is NOT marked as unique
+		// since it only participates in expression-based unique indexes
+		tableSQL := result.Tables[0].String()
+		// The column should NOT have UNIQUE keyword since there's no actual
+		// UNIQUE constraint, only unique expression-based indexes
+		if strings.Contains(tableSQL, "id_parent_folder uuid UNIQUE") {
+			t.Errorf("Column id_parent_folder incorrectly marked as UNIQUE.\nGenerated SQL:\n%s", tableSQL)
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
- Changed the condition for adding UNIQUE keyword. 
- Added a test for the problematic query - please check the logic, not sure if I followed your patterns. Also not sure if you accept it here or it should be part of some existing test file.

All current tests pass.

Fixes https://github.com/peterldowns/pgmigrate/issues/28