### PR TITLE
fix(cli): respect configured table name in ops subcommands

### DIFF
--- a/cmd/pgmigrate/root/ops/markapplied.go
+++ b/cmd/pgmigrate/root/ops/markapplied.go
@@ -56,14 +56,18 @@ pgmigrate ops mark-applied --all
 		defer db.Close()
 		dir := os.DirFS(migrationsDir.Value())
 		slogger, mlogger := shared.State.Logger()
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
 
 		// Execution
 		var applied []pgmigrate.AppliedMigration
 		if *MarkAppliedFlags.All {
 			slogger.Info("marking ALL as applied")
-			applied, err = pgmigrate.MarkAllApplied(ctx, db, dir, mlogger)
+			applied, err = m.MarkAllApplied(ctx, db)
 		} else {
-			applied, err = pgmigrate.MarkApplied(ctx, db, dir, mlogger, *MarkAppliedFlags.IDs...)
+			applied, err = m.MarkApplied(ctx, db, *MarkAppliedFlags.IDs...)
 		}
 		if err != nil {
 			return err

--- a/cmd/pgmigrate/root/ops/markunapplied.go
+++ b/cmd/pgmigrate/root/ops/markunapplied.go
@@ -59,13 +59,17 @@ pgmigrate ops mark-unapplied --all
 		defer db.Close()
 		dir := os.DirFS(migrationsDir.Value())
 		slogger, mlogger := shared.State.Logger()
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
 
 		// Execution
 		var removed []pgmigrate.AppliedMigration
 		if *MarkUnappliedFlags.All {
-			removed, err = pgmigrate.MarkAllUnapplied(ctx, db, dir, mlogger)
+			removed, err = m.MarkAllUnapplied(ctx, db)
 		} else {
-			removed, err = pgmigrate.MarkUnapplied(ctx, db, dir, mlogger, *MarkUnappliedFlags.IDs...)
+			removed, err = m.MarkUnapplied(ctx, db, *MarkUnappliedFlags.IDs...)
 		}
 		if err != nil {
 			return err

--- a/cmd/pgmigrate/root/ops/migrator.go
+++ b/cmd/pgmigrate/root/ops/migrator.go
@@ -1,0 +1,21 @@
+package ops
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/peterldowns/pgmigrate"
+)
+
+// newMigrator loads migrations from dir and returns a configured migrator for
+// ops commands, including the caller-provided table name and logger.
+func newMigrator(dir fs.FS, tableName string, logger pgmigrate.Logger) (*pgmigrate.Migrator, error) {
+	migrations, err := pgmigrate.Load(dir)
+	if err != nil {
+		return nil, fmt.Errorf("load migrations: %w", err)
+	}
+	m := pgmigrate.NewMigrator(migrations)
+	m.Logger = logger
+	m.TableName = tableName
+	return m, nil
+}

--- a/cmd/pgmigrate/root/ops/recalculatechecksum.go
+++ b/cmd/pgmigrate/root/ops/recalculatechecksum.go
@@ -60,13 +60,17 @@ pgmigrate ops recalculate-checksum --all
 		defer db.Close()
 		dir := os.DirFS(migrationsDir.Value())
 		slogger, mlogger := shared.State.Logger()
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
 
 		// Execution
 		var updated []pgmigrate.AppliedMigration
 		if *RecalculateChecksumFlags.All {
-			updated, err = pgmigrate.RecalculateAllChecksums(ctx, db, dir, mlogger)
+			updated, err = m.RecalculateAllChecksums(ctx, db)
 		} else {
-			updated, err = pgmigrate.RecalculateChecksums(ctx, db, dir, mlogger, *RecalculateChecksumFlags.IDs...)
+			updated, err = m.RecalculateChecksums(ctx, db, *RecalculateChecksumFlags.IDs...)
 		}
 		if err != nil {
 			return err

--- a/cmd/pgmigrate/root/ops/setchecksum.go
+++ b/cmd/pgmigrate/root/ops/setchecksum.go
@@ -61,8 +61,12 @@ pgmigrate ops set-checksum --id 123_example --checksum aaaaaaaaaaaaaaaaaaaaaaaaa
 		defer db.Close()
 		dir := os.DirFS(migrationsDir.Value())
 		slogger, mlogger := shared.State.Logger()
+		m, err := newMigrator(dir, shared.State.TableName().Value(), mlogger)
+		if err != nil {
+			return err
+		}
 
-		updated, err := pgmigrate.SetChecksums(ctx, db, dir, mlogger, pgmigrate.ChecksumUpdate{
+		updated, err := m.SetChecksums(ctx, db, pgmigrate.ChecksumUpdate{
 			MigrationID: *SetChecksumFlags.ID,
 			NewChecksum: *SetChecksumFlags.Checksum,
 		})


### PR DESCRIPTION
Fixes a bug where `pgmigrate ops` subcommands ignored the configured `table_name` (from config/env/flag) and always operated on the default migrations table.

- Updated ops subcommands to use a configured `Migrator` instead of package-level helpers:
  - `mark-applied`
  - `mark-unapplied`
  - `set-checksum`
  - `recalculate-checksum`

We probably want to remove the pgmigrate package methods for running migrations and instead force callers to create an explicit migrator instance. That's a breaking change so I'll handle that in later work.

## Testing
- unit tests and CI
