### PR TITLE
nit: consistently close sql rows, check for errors

### DIFF
--- a/internal/schema/compoundtypes.go
+++ b/internal/schema/compoundtypes.go
@@ -65,6 +65,7 @@ func LoadCompoundTypes(config DumpConfig, db *sql.DB) ([]*CompoundType, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var ct CompoundType
 		if err := rows.Scan(
@@ -77,7 +78,10 @@ func LoadCompoundTypes(config DumpConfig, db *sql.DB) ([]*CompoundType, error) {
 		}
 		types = append(types, &ct)
 	}
-	return Sort[string](types), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(types), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/constraints.go
+++ b/internal/schema/constraints.go
@@ -63,6 +63,7 @@ func LoadConstraints(config DumpConfig, db *sql.DB) ([]*Constraint, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var constraint Constraint
 		if err := rows.Scan(
@@ -84,7 +85,10 @@ func LoadConstraints(config DumpConfig, db *sql.DB) ([]*Constraint, error) {
 		}
 		constraints = append(constraints, &constraint)
 	}
-	return Sort[string](constraints), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(constraints), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/data.go
+++ b/internal/schema/data.go
@@ -94,7 +94,6 @@ and c.relname like $2;
 			if err != nil {
 				return nil, err
 			}
-			defer rows.Close()
 			for rows.Next() {
 				var schemaName string
 				var name string
@@ -110,6 +109,9 @@ and c.relname like $2;
 				})
 			}
 			if err := rows.Err(); err != nil {
+				return nil, err
+			}
+			if err := rows.Close(); err != nil {
 				return nil, err
 			}
 		} else {
@@ -138,7 +140,6 @@ from %s
 		if err != nil {
 			return nil, err
 		}
-		defer rows.Close()
 		columnTypeInfo, err := rows.ColumnTypes()
 		if err != nil {
 			return nil, err
@@ -176,6 +177,9 @@ from %s
 			d.rows = append(d.rows, ifaces...)
 		}
 		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		if err := rows.Close(); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/schema/data.go
+++ b/internal/schema/data.go
@@ -94,6 +94,7 @@ and c.relname like $2;
 			if err != nil {
 				return nil, err
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var schemaName string
 				var name string
@@ -107,6 +108,9 @@ and c.relname like $2;
 					OrderBy: d.OrderBy,
 					rows:    []any{},
 				})
+			}
+			if err := rows.Err(); err != nil {
+				return nil, err
 			}
 		} else {
 			toLoad = append(toLoad, &Data{
@@ -134,6 +138,7 @@ from %s
 		if err != nil {
 			return nil, err
 		}
+		defer rows.Close()
 		columnTypeInfo, err := rows.ColumnTypes()
 		if err != nil {
 			return nil, err
@@ -170,6 +175,9 @@ from %s
 			}
 			d.rows = append(d.rows, ifaces...)
 		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	}
-	return Sort[string](toLoad), nil
+	return Sort(toLoad), nil
 }

--- a/internal/schema/dependencies.go
+++ b/internal/schema/dependencies.go
@@ -21,6 +21,7 @@ func LoadDependencies(config DumpConfig, db *sql.DB) ([]*Dependency, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var dep Dependency
 		if err := rows.Scan(

--- a/internal/schema/domains.go
+++ b/internal/schema/domains.go
@@ -54,6 +54,7 @@ func LoadDomains(config DumpConfig, db *sql.DB) ([]*Domain, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var domain Domain
 		if err := rows.Scan(
@@ -69,7 +70,10 @@ func LoadDomains(config DumpConfig, db *sql.DB) ([]*Domain, error) {
 		}
 		domains = append(domains, &domain)
 	}
-	return Sort[string](domains), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(domains), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/enums.go
+++ b/internal/schema/enums.go
@@ -51,6 +51,7 @@ func LoadEnums(config DumpConfig, db *sql.DB) ([]*Enum, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var enum Enum
 		if err := rows.Scan(
@@ -66,7 +67,10 @@ func LoadEnums(config DumpConfig, db *sql.DB) ([]*Enum, error) {
 		}
 		enums = append(enums, &enum)
 	}
-	return Sort[string](enums), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(enums), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/extensions.go
+++ b/internal/schema/extensions.go
@@ -39,6 +39,7 @@ func LoadExtensions(config DumpConfig, db *sql.DB) ([]*Extension, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var extension Extension
 		if err := rows.Scan(
@@ -52,7 +53,10 @@ func LoadExtensions(config DumpConfig, db *sql.DB) ([]*Extension, error) {
 		}
 		extensions = append(extensions, &extension)
 	}
-	return Sort[string](extensions), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(extensions), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/functions.go
+++ b/internal/schema/functions.go
@@ -45,6 +45,7 @@ func LoadFunctions(config DumpConfig, db *sql.DB) ([]*Function, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var function Function
 		if err := rows.Scan(
@@ -64,7 +65,10 @@ func LoadFunctions(config DumpConfig, db *sql.DB) ([]*Function, error) {
 		}
 		functions = append(functions, &function)
 	}
-	return Sort[string](functions), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(functions), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/indexes.go
+++ b/internal/schema/indexes.go
@@ -61,6 +61,7 @@ func LoadIndexes(config DumpConfig, db *sql.DB) ([]*Index, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var index Index
 		if err := rows.Scan(
@@ -91,7 +92,10 @@ func LoadIndexes(config DumpConfig, db *sql.DB) ([]*Index, error) {
 		}
 		indexes = append(indexes, &index)
 	}
-	return Sort[string](indexes), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(indexes), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/sequences.go
+++ b/internal/schema/sequences.go
@@ -93,6 +93,7 @@ func LoadSequences(config DumpConfig, db *sql.DB) ([]*Sequence, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var sequence Sequence
 		if err := rows.Scan(
@@ -115,7 +116,10 @@ func LoadSequences(config DumpConfig, db *sql.DB) ([]*Sequence, error) {
 		}
 		sequences = append(sequences, &sequence)
 	}
-	return Sort[string](sequences), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(sequences), nil
 }
 
 var sequencesQuery = query(`--sql

--- a/internal/schema/tables.go
+++ b/internal/schema/tables.go
@@ -84,7 +84,7 @@ CREATE TABLE %s (
   %s
 );
 	`), pgtools.Identifier(t.Schema, t.Name), strings.Join(colDefs, ",\n  "))
-	constraintsByName := asMap[string](t.Constraints)
+	constraintsByName := asMap(t.Constraints)
 
 	if t.Comment.Valid {
 		tableDef += "\n\n" + fmt.Sprintf(
@@ -169,6 +169,7 @@ func LoadTables(config DumpConfig, db *sql.DB) ([]*Table, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var current *Table
 	for rows.Next() {
 		var table Table
@@ -198,7 +199,10 @@ func LoadTables(config DumpConfig, db *sql.DB) ([]*Table, error) {
 		column.BelongsTo = current.OID
 		current.Columns = append(current.Columns, &column)
 	}
-	return Sort[string](tables), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(tables), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/toposort_test.go
+++ b/internal/schema/toposort_test.go
@@ -25,7 +25,7 @@ func TestToposortWithCycles(t *testing.T) {
 	f := newSnode("f", "e")
 	z := newSnode("z")
 	initial := []snode{a, b, c, d, e, f, z}
-	nodes := schema.Sort[string](initial)
+	nodes := schema.Sort(initial)
 
 	expected := []snode{z, e, d, c, b, a, f}
 	if !check.Equal(t, asKeys(expected), asKeys(nodes)) {
@@ -47,7 +47,7 @@ func TestInitialOrderIndependent(t *testing.T) {
 		{z, a, x},
 		{z, x, a},
 	} {
-		nodes := schema.Sort[string](initial)
+		nodes := schema.Sort(initial)
 		expected := []snode{z, a, x}
 		if !check.Equal(t, asKeys(expected), asKeys(nodes)) {
 			t.Log(" initial:", initial)
@@ -74,7 +74,7 @@ func TestComplicatedToposort(t *testing.T) {
 	y := newSnode("y", "z")
 	z := newSnode("z")
 	nodes := []snode{a, b, c, d, e, x, y, z}
-	nodes = schema.Sort[string](nodes)
+	nodes = schema.Sort(nodes)
 
 	// depth 3: E
 	// depth 2: C, D

--- a/internal/schema/triggers.go
+++ b/internal/schema/triggers.go
@@ -45,6 +45,7 @@ func LoadTriggers(config DumpConfig, db *sql.DB) ([]*Trigger, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var trigger Trigger
 		if err := rows.Scan(
@@ -61,7 +62,10 @@ func LoadTriggers(config DumpConfig, db *sql.DB) ([]*Trigger, error) {
 		}
 		triggers = append(triggers, &trigger)
 	}
-	return Sort[string](triggers), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(triggers), nil
 }
 
 // This query is inspired heavily by:

--- a/internal/schema/views.go
+++ b/internal/schema/views.go
@@ -70,6 +70,7 @@ func LoadViews(config DumpConfig, db *sql.DB) ([]*View, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var current *View
 	for rows.Next() {
 		var view View
@@ -100,7 +101,10 @@ func LoadViews(config DumpConfig, db *sql.DB) ([]*View, error) {
 		}
 		current.Columns = append(current.Columns, column)
 	}
-	return Sort[string](views), nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return Sort(views), nil
 }
 
 // This query was inspired heavily by:


### PR DESCRIPTION
[Detail](https://detail.dev) reported a number of edge-case problems with the data-loading logic in internal/schema. Fundamentally, I was being lazy, and omitted some basic error checking.

- Need to `defer rows.Close()` after making a query
- Need to check `rows.Err()` after iterating through the rows.

This PR addresses these issues consistently throughout all the data-loading code.

Additionally, with newer versions of golang, the compiler is able to infer more
types when calling generic functions, so I've fixed all the editor warnings
related to not needing to infer the types when calling the `Sort()` method.

## Testing
- CI and existing unit tests.
